### PR TITLE
u126: Manager Anpassungen für den Sprint

### DIFF
--- a/core/src/com/gatdsen/manager/Controller.java
+++ b/core/src/com/gatdsen/manager/Controller.java
@@ -7,8 +7,6 @@ import java.util.concurrent.ArrayBlockingQueue;
 import java.util.concurrent.BlockingQueue;
 
 /**
- * Provides an access-controlled interface to send commands to players
- * <p>
  * Ermöglicht die Kontrolle eines bestimmten Charakters.
  * Ist nur für einen einzelnen Zug gültig und deaktiviert sich nach Ende des aktuellen Zuges.
  */

--- a/core/src/com/gatdsen/manager/Game.java
+++ b/core/src/com/gatdsen/manager/Game.java
@@ -4,6 +4,7 @@ import com.gatdsen.manager.command.Command;
 import com.gatdsen.manager.player.Bot;
 import com.gatdsen.manager.player.Player;
 import com.gatdsen.manager.player.PlayerHandler;
+import com.gatdsen.manager.player.data.PlayerInformation;
 import com.gatdsen.networking.ProcessPlayerHandler;
 import com.gatdsen.simulation.PlayerController;
 import com.gatdsen.simulation.GameState;
@@ -219,15 +220,12 @@ public class Game extends Executable {
     }
 
     protected String[] getPlayerNames() {
-        // TODO
-        /*String[] names = new String[players.length];
-        int i = 0;
-        for (Player p : players) {
-            names[i] = p.getName();
-            i++;
+        String[] names = new String[playerHandlers.length];
+        for (int i = 0; i < playerHandlers.length; i++) {
+            PlayerInformation information = playerHandlers[i].getPlayerInformation();
+            names[i] = information != null ? information.getName() : "Player " + i;
         }
-        return names;*/
-        return new String[]{"Player 1", "Player 2"};
+        return names;
     }
 
     private void awaitFutures(Future<?>[] futures) {

--- a/core/src/com/gatdsen/manager/Game.java
+++ b/core/src/com/gatdsen/manager/Game.java
@@ -185,6 +185,9 @@ public class Game extends Executable {
                 }
             }
             awaitFutures(futures);
+            if (inputGenerator != null) {
+                inputGenerator.endTurn();
+            }
             //Contains actions produced by ending the turn (after last command is executed)
             ActionLog finalLog = simulation.endTurn();
             if (saveReplay) {

--- a/core/src/com/gatdsen/manager/Game.java
+++ b/core/src/com/gatdsen/manager/Game.java
@@ -7,6 +7,7 @@ import com.gatdsen.manager.player.PlayerHandler;
 import com.gatdsen.networking.ProcessPlayerHandler;
 import com.gatdsen.simulation.PlayerController;
 import com.gatdsen.simulation.GameState;
+import com.gatdsen.simulation.PlayerState;
 import com.gatdsen.simulation.Simulation;
 import com.gatdsen.simulation.action.ActionLog;
 import com.gatdsen.simulation.campaign.CampaignResources;
@@ -142,7 +143,14 @@ public class Game extends Executable {
                     }
             }
 
+            PlayerState[] playerStates = state.getPlayerStates();
             for (int playerIndex = 0; playerIndex < playerHandlers.length; playerIndex++) {
+                // Wenn der PlayerState des Spielers deaktiviert ist, da er bspw. keine Leben mehr hat oder
+                // disqualifiziert wurde, wird der Spieler übersprungen und dessen executeTurn() nicht aufgerufen.
+                if (playerStates[playerIndex].isDeactivated()) {
+                    continue;
+                }
+
                 ActionLog firstLog = simulation.clearAndReturnActionLog();
                 if (saveReplay)
                     gameResults.addActionLog(firstLog);

--- a/core/src/com/gatdsen/manager/Game.java
+++ b/core/src/com/gatdsen/manager/Game.java
@@ -72,7 +72,7 @@ public class Game extends Executable {
                 if (!gui) {
                     throw new RuntimeException("HumanPlayers can't be used without GUI to capture inputs");
                 }
-                playerHandler = new LocalPlayerHandler(playerClass, inputGenerator);
+                playerHandler = new LocalPlayerHandler(playerClass, playerIndex, inputGenerator);
             }
 
             playerHandlers[playerIndex] = playerHandler;

--- a/core/src/com/gatdsen/manager/InputProcessor.java
+++ b/core/src/com/gatdsen/manager/InputProcessor.java
@@ -5,7 +5,7 @@ import com.gatdsen.manager.player.HumanPlayer;
 public interface InputProcessor {
 
 
-	void activateTurn(HumanPlayer currentPlayer);
+	void activateTurn(HumanPlayer player, int playerIndex);
 
 	void endTurn();
 

--- a/core/src/com/gatdsen/manager/LocalPlayerHandler.java
+++ b/core/src/com/gatdsen/manager/LocalPlayerHandler.java
@@ -17,8 +17,8 @@ public final class LocalPlayerHandler extends PlayerHandler {
     private final PlayerThread playerThread = new PlayerThread();
     private final InputProcessor inputGenerator;
 
-    public LocalPlayerHandler(Class<? extends Player> playerClass, InputProcessor inputGenerator) {
-        super(playerClass);
+    public LocalPlayerHandler(Class<? extends Player> playerClass, int playerIndex, InputProcessor inputGenerator) {
+        super(playerClass, playerIndex);
         this.inputGenerator = inputGenerator;
     }
 
@@ -41,7 +41,7 @@ public final class LocalPlayerHandler extends PlayerHandler {
     @Override
     public Future<?> init(GameState gameState, boolean isDebug, long seed, CommandHandler commandHandler) {
         return executor.execute(() -> {
-            BlockingQueue<Command> commands = playerThread.init(gameState, isDebug, seed);
+            BlockingQueue<Command> commands = playerThread.init(gameState, isDebug, seed, playerIndex);
             Command command;
             do {
                 try {

--- a/core/src/com/gatdsen/manager/PlayerThread.java
+++ b/core/src/com/gatdsen/manager/PlayerThread.java
@@ -33,6 +33,7 @@ public final class PlayerThread {
     private InputProcessor inputGenerator;
 
     private boolean isDebug;
+    private int playerIndex;
 
     private boolean isCreated = false;
     private boolean isInitialized = false;
@@ -67,11 +68,12 @@ public final class PlayerThread {
         return controller.commands;
     }
 
-    public BlockingQueue<Command> init(GameState state, boolean isDebug, long seed) {
+    public BlockingQueue<Command> init(GameState state, boolean isDebug, long seed, int playerIndex) {
         isInitialized = true;
         this.isDebug = isDebug;
+        this.playerIndex = playerIndex;
         Controller controller = createController();
-        StaticGameState staticState = new StaticGameState(state);
+        StaticGameState staticState = new StaticGameState(state, playerIndex);
         switch (player.getType()) {
             case Human ->{
                 Future<?> future = executor.execute(() -> {
@@ -96,7 +98,7 @@ public final class PlayerThread {
         Controller controller = createController();
         Future<?> future = executor.execute(() -> {
             Thread.currentThread().setName("Run_Thread_Player_" + player.getName());
-            player.executeTurn(new StaticGameState(state), controller);
+            player.executeTurn(new StaticGameState(state, playerIndex), controller);
         });
         Thread futureExecutor = switch (player.getType()) {
             case Human -> new Thread(() -> {

--- a/core/src/com/gatdsen/manager/PlayerThread.java
+++ b/core/src/com/gatdsen/manager/PlayerThread.java
@@ -103,9 +103,8 @@ public final class PlayerThread {
         Thread futureExecutor = switch (player.getType()) {
             case Human -> new Thread(() -> {
                 Thread.currentThread().setName("Future_Executor_Player_" + player.getName());
-                inputGenerator.activateTurn((HumanPlayer) player);
+                inputGenerator.activateTurn((HumanPlayer) player, playerIndex);
                 awaitHumanPlayerFuture(future, controller, HUMAN_EXECUTE_TURN_TIMEOUT);
-                inputGenerator.endTurn();
             });
             case AI -> new Thread(() -> {
                 Thread.currentThread().setName("Future_Executor_Player_" + player.getName());

--- a/core/src/com/gatdsen/manager/PlayerThread.java
+++ b/core/src/com/gatdsen/manager/PlayerThread.java
@@ -71,11 +71,12 @@ public final class PlayerThread {
         isInitialized = true;
         this.isDebug = isDebug;
         Controller controller = createController();
+        StaticGameState staticState = new StaticGameState(state);
         switch (player.getType()) {
             case Human ->{
                 Future<?> future = executor.execute(() -> {
                     Thread.currentThread().setName("Init_Thread_Player_" + player.getName());
-                    player.init(new StaticGameState(state));
+                    player.init(staticState);
                 });
                 awaitHumanPlayerFuture(future, controller, HUMAN_EXECUTE_INIT_TIMEOUT);
             }
@@ -83,7 +84,7 @@ public final class PlayerThread {
                 Future<?> future = executor.execute(() -> {
                     Thread.currentThread().setName("Init_Thread_Player_" + player.getName());
                     ((Bot) player).setRnd(seed);
-                    player.init(new StaticGameState(state));
+                    player.init(staticState);
                 });
                 awaitBotFuture(future, controller, AI_EXECUTE_INIT_TIMEOUT);
             }

--- a/core/src/com/gatdsen/manager/StaticGameState.java
+++ b/core/src/com/gatdsen/manager/StaticGameState.java
@@ -1,43 +1,79 @@
 package com.gatdsen.manager;
 
 import com.gatdsen.simulation.GameState;
+import com.gatdsen.simulation.PlayerState;
 
+/**
+ * Diese Klasse repräsentiert den aktuellen Zustand des Spiels, dementsprechend auch den aktuellen Zustand aller
+ * Spieler (siehe {@link StaticPlayerState} bzw. {@link #getMyPlayerState()}).
+ * <p>
+ * Wie es der Name bereits andeutet, ist diese Klasse statisch. Das bedeutet, dass sie sich nicht bspw. über die
+ * Dauer eines Zuges verändert.
+ */
 public final class StaticGameState {
 
     private final GameState state;
     private final int playerIndex;
-    private final StaticPlayerState[] playerStates;
+    private final StaticPlayerState[] staticPlayerStates;
 
     StaticGameState(GameState state, int playerIndex) {
         this.state = state;
         this.playerIndex = playerIndex;
-        this.playerStates = new StaticPlayerState[state.getPlayerCount()];
+        staticPlayerStates = new StaticPlayerState[state.getPlayerCount()];
+        PlayerState[] playerStates = state.getPlayerStates();
+        for (int i = 0; i < state.getPlayerCount(); i++) {
+            staticPlayerStates[i] = new StaticPlayerState(playerStates[i]);
+        }
     }
 
-    public StaticPlayerState getPlayerState() {
-        // TODO
-        // return ;
-        return null;
+    /**
+     * @return Gibt den PlayerState des aktuellen Spielers zurück
+     */
+    public StaticPlayerState getMyPlayerState() {
+        return staticPlayerStates[playerIndex];
     }
 
+    /**
+     * @return Gibt den PlayerState des Gegners zurück
+     */
     public StaticPlayerState getEnemyPlayerState() {
-        // TODO
-        // return ;
-        return null;
+        return staticPlayerStates[(playerIndex + 1) % state.getPlayerCount()];
     }
 
+    /**
+     * @return Gibt die aktuelle Runde zurück.
+     * <p>
+     * Dieser Wert ist nicht nur nützlich, um zu überprüfen, wie viele Runden das Spiel bereits andauert, sondern
+     * ebenfalls um zu überprüfen, ob man eine Runde aussetzen musste, da in diesem Fall die {@code executeTurn()} Methode des
+     * Spielers nicht aufgerufen wird.
+     */
     public int getTurn() {
         return state.getTurn();
     }
 
+    /**
+     * @return Gibt die Anzahl der Spieler zurück, die am Spiel teilnehmen.
+     * <p>
+     * Im Normalfall sind dies zwei Spieler.
+     */
     public int getPlayerCount() {
         return state.getPlayerCount();
     }
 
+    /**
+     * @return Gibt die Breite des Spielfeldes zurück.
+     * <p>
+     * Diese Methode kann bspw. in Verbindung mit {@link StaticPlayerState#getBoard()} verwendet werden.
+     */
     public int getBoardSizeX() {
         return state.getBoardSizeX();
     }
 
+    /**
+     * @return Gibt die Höhe des Spielfeldes zurück.
+     * <p>
+     * Diese Methode kann bspw. in Verbindung mit {@link StaticPlayerState#getBoard()} verwendet werden.
+     */
     public int getBoardSizeY() {
         return state.getBoardSizeY();
     }

--- a/core/src/com/gatdsen/manager/StaticGameState.java
+++ b/core/src/com/gatdsen/manager/StaticGameState.java
@@ -5,10 +5,12 @@ import com.gatdsen.simulation.GameState;
 public final class StaticGameState {
 
     private final GameState state;
+    private final int playerIndex;
     private final StaticPlayerState[] playerStates;
 
-    StaticGameState(GameState state) {
+    StaticGameState(GameState state, int playerIndex) {
         this.state = state;
+        this.playerIndex = playerIndex;
         this.playerStates = new StaticPlayerState[state.getPlayerCount()];
     }
 

--- a/core/src/com/gatdsen/manager/StaticPlayerState.java
+++ b/core/src/com/gatdsen/manager/StaticPlayerState.java
@@ -2,7 +2,16 @@ package com.gatdsen.manager;
 
 import com.gatdsen.simulation.PlayerState;
 import com.gatdsen.simulation.Tile;
+import com.gatdsen.simulation.PathTile;
+import com.gatdsen.simulation.Tower;
 
+/**
+ * Diese Klasse repräsentiert den aktuellen Zustand eines Spielers.
+ * Dies umfasst sowohl Attribute, wie dessen Leben und Geld, als auch dessen Map.
+ * <p>
+ * Wie es der Name bereits andeutet, ist diese Klasse statisch. Das bedeutet, dass sie sich nicht bspw. über die
+ * Dauer eines Zuges verändert.
+ */
 public final class StaticPlayerState {
 
     private final PlayerState state;
@@ -11,23 +20,40 @@ public final class StaticPlayerState {
         this.state = state;
     }
 
-    PlayerState getPlayerState() {
-        return state;
+    /**
+     * @return Die Id des Spielers, welche verwendet wird, um den Spieler bspw. aus einer Liste
+     * von {@link StaticPlayerState}s zu identifizieren.
+     */
+    public int getId() {
+        return state.getIndex();
     }
 
+    /**
+     * @return Die Anzahl der verbleibenden Leben des Spielers
+     */
     public int getHealth() {
         return state.getHealth();
     }
 
+    /**
+     * @return Die Anzahl des angesparten Geldes des Spielers
+     */
     public int getMoney() {
-        // TODO
-        // return state.getMoney();
-        return 0;
+        return state.getMoney();
     }
 
-    public Tile[][] getMap() {
-        // TODO
-        //return state.getMap();
-        return null;
+    /**
+     * Gibt einen zwei-dimensionalen Array von {@link Tile}s zurück, indexiert anhand ihrer x- und y-Koordinaten.
+     * <p> - {@link PathTile} Instanzen symbolisieren dabei einen Pfad.
+     * <p> - {@link Tower} Instanzen symbolisieren einen Tower.
+     * <p> - {@code null} symbolisiert ein leeres Feld, an welchem sich weder ein Pfad noch ein Tower befindet. An diesen
+     * Feldern können neue Türme platziert werden.
+     * <p>
+     * Das Array ist über die x- und y-Koordinate des {@link Tile}s indexiert.
+     * {@code map[x][y]} gibt also das {@link Tile} an der Position {@code (x, y)} zurück.
+     * @return Die Map des Spielers
+     */
+    public Tile[][] getBoard() {
+        return state.getBoard();
     }
 }

--- a/core/src/com/gatdsen/manager/command/DisqualifyCommand.java
+++ b/core/src/com/gatdsen/manager/command/DisqualifyCommand.java
@@ -14,7 +14,7 @@ public class DisqualifyCommand extends EndTurnCommand {
 
     @Override
     protected ActionLog onExecute(PlayerHandler playerHandler) {
-        // TODO: playerHandler.getPlayerController().disqualify();
+        playerHandler.getPlayerController().disqualify();
         return super.onExecute(playerHandler);
     }
 }

--- a/core/src/com/gatdsen/manager/player/HumanPlayer.java
+++ b/core/src/com/gatdsen/manager/player/HumanPlayer.java
@@ -104,6 +104,25 @@ public class HumanPlayer extends Player {
     }
 
     /**
+     * Ruft den {@link Controller} des {@link HumanPlayer} auf, um einen Turm auf dem Spielfeld zu platzieren.
+     * @param x x-Koordinate, an der der Turm platziert werden soll
+     * @param y y-Koordinate, an der der Turm platziert werden soll
+     * @param type Typ des Turms, der platziert werden soll
+     */
+    public void placeTower(int x, int y, Tower.TowerType type) {
+        controller.placeTower(x, y, type);
+    }
+
+    /**
+     * Ruft den {@link Controller} des {@link HumanPlayer} auf, um einen Turm auf dem Spielfeld zu verbessern.
+     * @param x x-Koordinate, an der sich der Turm befindet
+     * @param y y-Koordinate, an der sich der Turm befindet
+     */
+    public void upgradeTower(int x, int y) {
+        controller.upgradeTower(x, y);
+    }
+
+    /**
      * Endet den aktuellen Zug des {@link HumanPlayer} vorzeitig.
      * Wird aufgerufen, wenn {@link HumanPlayer#KEY_CHARACTER_END_TURN} gedrückt wird.
      */
@@ -155,13 +174,13 @@ public class HumanPlayer extends Player {
                 selectedTile.x = Math.min(selectedTile.x + 1, state.getBoardSizeX() - 1);
                 break;
             case KEY_CHARACTER_TOWER_PLACE:
-                controller.placeTower(selectedTile.x, selectedTile.y, Tower.TowerType.BASIC_TOWER);
+                placeTower(selectedTile.x, selectedTile.y, Tower.TowerType.BASIC_TOWER);
                 break;
             case KEY_CHARACTER_TOWER_UPGRADE:
-                controller.upgradeTower(selectedTile.x, selectedTile.y);
+                upgradeTower(selectedTile.x, selectedTile.y);
                 break;
             case KEY_CHARACTER_END_TURN:
-                this.endCurrentTurn();
+                endCurrentTurn();
                 break;
         }
     }
@@ -177,10 +196,6 @@ public class HumanPlayer extends Player {
                 }
             }
         }
-    }
-
-    public Controller getController() {
-        return controller;
     }
 
     @Override

--- a/core/src/com/gatdsen/manager/player/PlayerHandler.java
+++ b/core/src/com/gatdsen/manager/player/PlayerHandler.java
@@ -11,14 +11,16 @@ import java.util.concurrent.Future;
 public abstract class PlayerHandler {
 
     protected final Class<? extends Player> playerClass;
+    protected final int playerIndex;
     protected PlayerController controller;
     protected PlayerInformation information;
     protected long seedModifier;
 
     protected int turnsToMiss = 0;
 
-    public PlayerHandler(Class<? extends Player> playerClass) {
+    public PlayerHandler(Class<? extends Player> playerClass, int playerIndex) {
         this.playerClass = playerClass;
+        this.playerIndex = playerIndex;
     }
 
     public final boolean isHumanPlayer() {

--- a/core/src/com/gatdsen/manager/player/PlayerHandler.java
+++ b/core/src/com/gatdsen/manager/player/PlayerHandler.java
@@ -39,6 +39,10 @@ public abstract class PlayerHandler {
         return controller;
     }
 
+    public final PlayerInformation getPlayerInformation() {
+        return information;
+    }
+
     public final void setPlayerInformation(PlayerInformation information) {
         this.information = information;
     }

--- a/core/src/com/gatdsen/manager/player/data/BotInformation.java
+++ b/core/src/com/gatdsen/manager/player/data/BotInformation.java
@@ -4,12 +4,20 @@ import com.gatdsen.manager.player.Player;
 
 public class BotInformation extends PlayerInformation {
 
-    public final String studentName;
-    public final int matrikel;
+    protected final String studentName;
+    protected final int matrikel;
 
     public BotInformation(Player.PlayerType type, String name, String studentName, int matrikel) {
         super(type, name);
         this.studentName = studentName;
         this.matrikel = matrikel;
+    }
+
+    public String getStudentName() {
+        return studentName;
+    }
+
+    public int getMatrikel() {
+        return matrikel;
     }
 }

--- a/core/src/com/gatdsen/manager/player/data/PlayerInformation.java
+++ b/core/src/com/gatdsen/manager/player/data/PlayerInformation.java
@@ -6,11 +6,19 @@ import java.io.Serializable;
 
 public class PlayerInformation implements Serializable {
 
-    public final Player.PlayerType type;
-    public final String name;
+    protected final Player.PlayerType type;
+    protected final String name;
 
     public PlayerInformation(Player.PlayerType type, String name) {
         this.type = type;
         this.name = name;
+    }
+
+    public Player.PlayerType getType() {
+        return type;
+    }
+
+    public String getName() {
+        return name;
     }
 }

--- a/core/src/com/gatdsen/networking/BotProcess.java
+++ b/core/src/com/gatdsen/networking/BotProcess.java
@@ -66,7 +66,7 @@ public class BotProcess {
                 if (!playerThread.isCreated()) {
                     throw new RuntimeException("Received GameInformation before CreatePlayerInformation.");
                 }
-                commands = playerThread.init(gameInformation.state(), gameInformation.isDebug(), gameInformation.seed());
+                commands = playerThread.init(gameInformation.state(), gameInformation.isDebug(), gameInformation.seed(), gameInformation.playerIndex());
             } else if (information instanceof TurnInformation turnInformation) {
                 if (!playerThread.isInitialized()) {
                     throw new RuntimeException("Received TurnInformation before GameInformation.");

--- a/core/src/com/gatdsen/networking/ProcessPlayerHandler.java
+++ b/core/src/com/gatdsen/networking/ProcessPlayerHandler.java
@@ -35,9 +35,9 @@ public final class ProcessPlayerHandler extends PlayerHandler {
     private ProcessCommunicator communicator;
     private Process process;
 
-    public ProcessPlayerHandler(Class<? extends Player> playerClass, int gameId, int playerId) {
-        super(playerClass);
-        remoteReferenceName = stubNamePrefix + gameId + "_" + playerId;
+    public ProcessPlayerHandler(Class<? extends Player> playerClass, int gameId, int playerIndex) {
+        super(playerClass, playerIndex);
+        remoteReferenceName = stubNamePrefix + gameId + "_" + playerIndex;
         createRegistry();
         createProcess();
     }
@@ -115,7 +115,7 @@ public final class ProcessPlayerHandler extends PlayerHandler {
     @Override
     public Future<?> init(GameState gameState, boolean isDebug, long seed, CommandHandler commandHandler) {
         try {
-            communicator.queueInformation(new GameInformation(gameState, isDebug, seed));
+            communicator.queueInformation(new GameInformation(gameState, isDebug, seed, playerIndex));
         } catch (RemoteException e) {
             throw new RuntimeException(e);
         }

--- a/core/src/com/gatdsen/networking/data/GameInformation.java
+++ b/core/src/com/gatdsen/networking/data/GameInformation.java
@@ -2,5 +2,5 @@ package com.gatdsen.networking.data;
 
 import com.gatdsen.simulation.GameState;
 
-public record GameInformation(GameState state, boolean isDebug, long seed) implements CommunicatedInformation {
+public record GameInformation(GameState state, boolean isDebug, long seed, int playerIndex) implements CommunicatedInformation {
 }

--- a/core/src/com/gatdsen/ui/hud/InputHandler.java
+++ b/core/src/com/gatdsen/ui/hud/InputHandler.java
@@ -115,7 +115,7 @@ public class InputHandler implements InputProcessor, com.gatdsen.manager.InputPr
         if (currentPlayer == null) {
             return;
         }
-        currentPlayer.getController().placeTower(x, y, Tower.TowerType.BASIC_TOWER);
+        currentPlayer.placeTower(x, y, Tower.TowerType.BASIC_TOWER);
     }
 
     /**

--- a/core/src/com/gatdsen/ui/hud/InputHandler.java
+++ b/core/src/com/gatdsen/ui/hud/InputHandler.java
@@ -8,6 +8,11 @@ import com.gatdsen.simulation.Tower;
 import com.gatdsen.ui.menu.Hud;
 import com.gatdsen.ui.menu.InGameScreen;
 
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
 public class InputHandler implements InputProcessor, com.gatdsen.manager.InputProcessor {
 
 
@@ -29,7 +34,8 @@ public class InputHandler implements InputProcessor, com.gatdsen.manager.InputPr
 
     private final int KEY_TOGGLE_DEBUG = Input.Keys.F3;
 
-    private HumanPlayer currentPlayer;
+    /** Eine Liste aller HumanPlayer, die gerade am Zug sind, indexiert nach ihrer PlayerId */
+    private Map<Integer, HumanPlayer> currentPlayers = new HashMap<>();
     private Vector2 lastMousePosition;
     private Vector2 deltaMouseMove;
     private boolean leftMousePressed;
@@ -59,12 +65,11 @@ public class InputHandler implements InputProcessor, com.gatdsen.manager.InputPr
     }
 
 
-    public void activateTurn(HumanPlayer humanPlayer) {
-
-        currentPlayer = humanPlayer;
+    public void activateTurn(HumanPlayer player, int playerIndex) {
+        currentPlayers.put(playerIndex, player);
 
         if (uiMessenger != null) {
-            uiMessenger.startTurnTimer(humanPlayer.getTurnDuration(), true);
+            uiMessenger.startTurnTimer(player.getTurnDuration(), true);
         }
 
 //        System.out.printf("Activating turn for player %s\n", humanPlayer.toString());
@@ -74,15 +79,21 @@ public class InputHandler implements InputProcessor, com.gatdsen.manager.InputPr
 
     public void endTurn() {
         turnInProgress = false;
-        currentPlayer.endCurrentTurn();
+        for (HumanPlayer player : currentPlayers.values()) {
+            player.endCurrentTurn();
+        }
+        currentPlayers.clear();
         if (uiMessenger != null) {
             uiMessenger.stopTurnTimer();
         }
     }
 
     public void tick(float delta) {
-        if (turnInProgress && currentPlayer != null) {
-            currentPlayer.tick(delta);
+        if (!turnInProgress) {
+            return;
+        }
+        for (HumanPlayer player : currentPlayers.values()) {
+            player.tick(delta);
         }
     }
 
@@ -94,13 +105,17 @@ public class InputHandler implements InputProcessor, com.gatdsen.manager.InputPr
      */
     private void processMouseAim(int screenX, int screenY) {
         Vector2 worldCursorPos = ingameScreen.toWorldCoordinates(new Vector2(screenX, screenY));
-        if (currentPlayer != null) {
-            //ToDo do stuff
-        }
+        //ToDo do stuff
+        /*if (currentPlayer != null) {
+        }*/
     }
 
-    public void playerFieldLeftClicked(int team, int x, int y){
-        currentPlayer.getController().placeTower(x,y, Tower.TowerType.BASIC_TOWER);
+    public void playerFieldLeftClicked(int playerId, int x, int y) {
+        HumanPlayer currentPlayer = currentPlayers.get(playerId);
+        if (currentPlayer == null) {
+            return;
+        }
+        currentPlayer.getController().placeTower(x, y, Tower.TowerType.BASIC_TOWER);
     }
 
     /**
@@ -172,9 +187,12 @@ public class InputHandler implements InputProcessor, com.gatdsen.manager.InputPr
             case KEY_TOGGLE_SCORES:
                 hud.toggleScores();
             default:
-                if (turnInProgress && currentPlayer != null) {
-                    ingameScreen.skipTurnStart();
-                    currentPlayer.processKeyDown(keycode);
+                if (!turnInProgress) {
+                    break;
+                }
+                ingameScreen.skipTurnStart();
+                for (HumanPlayer player : currentPlayers.values()) {
+                    player.processKeyDown(keycode);
                 }
                 break;
         }
@@ -215,8 +233,11 @@ public class InputHandler implements InputProcessor, com.gatdsen.manager.InputPr
                 cameraZoomPressed -= 1;
                 break;
             default:
-                if (turnInProgress && currentPlayer != null) {
-                    currentPlayer.processKeyUp(keycode);
+                if (!turnInProgress) {
+                    break;
+                }
+                for (HumanPlayer player : currentPlayers.values()) {
+                    player.processKeyUp(keycode);
                 }
                 break;
         }

--- a/core/src/test/java/com/gatdsen/manager/TestBotMissTurn.java
+++ b/core/src/test/java/com/gatdsen/manager/TestBotMissTurn.java
@@ -37,7 +37,7 @@ public class TestBotMissTurn {
     }
 
     private void testBot(Class<? extends Bot> botClass) {
-        LocalPlayerHandler playerHandler = new LocalPlayerHandler(botClass, null);
+        LocalPlayerHandler playerHandler = new LocalPlayerHandler(botClass, 0, null);
         awaitFuture(playerHandler.create(command -> command.run(playerHandler)));
         awaitFuture(playerHandler.init(dummySimulation.getState(), false, 1337, command -> command.run(playerHandler)));
         awaitFuture(playerHandler.executeTurn(dummySimulation.getState(), command -> command.run(playerHandler)));


### PR DESCRIPTION
- DisqualifyCommand ruft nun PlayerController.disqualify() auf
- Überspringen von deaktivierten PlayerStates, sodass deren executeTurn() Methode nicht mehr ausgeführt wird
- Verbesserung der API und Dokumentation in StaticGameState, StaticPlayerState und Controller
- Parallele Ausführung der PlayerHandler.create(), PlayerHandler.init() und PlayerHandler.executeTurn() Methoden in der Game Klasse
- getPlayerNames() Methode der Game Klasse gibt nun wieder die Namen der Spieler zurück
- InputHandler Klasse kann nun mit mehreren HumanPlayern gleichzeitig arbeiten, sodass deren Runden parallel laufen können
- getController() Methode aus dem HumanPlayer entfernt, da lieber die placeTower() und upgradeTower() Helfermethoden verwendet werden sollen, damit Controllerobjekte nicht unnötig in andere interne Komponenten weiter gereicht werden